### PR TITLE
update documentation url to avoid redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Please visit the URL below for Crypto.com's official Exchange API documentation:
 
-[https://crypto.com/exchange-doc](https://crypto.com/exchange-doc)
+[https://exchange-docs.crypto.com/](https://exchange-docs.crypto.com/)


### PR DESCRIPTION
A simple fix which replaces https://crypto.com/exchange-doc by https://exchange-docs.crypto.com/ in order to avoid useless redirection.